### PR TITLE
feat(chat): improve chat UI - char counter, copy button, example prompts

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { ChangeEvent, FormEvent, KeyboardEvent } from "react";
-import { Send } from "lucide-react";
+import { Send, Loader2 } from "lucide-react";
+
+const MAX_CHARS = 2000;
 
 interface MessageInputProps {
   input: string;
@@ -16,11 +18,15 @@ export function MessageInput({
   handleSubmit,
   isLoading,
 }: MessageInputProps) {
+  const charCount = input.length;
+  const isOverLimit = charCount > MAX_CHARS;
+  const isNearLimit = charCount > MAX_CHARS * 0.85;
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       const form = e.currentTarget.form;
-      if (form) {
+      if (form && !isOverLimit) {
         form.requestSubmit();
       }
     }
@@ -35,16 +41,46 @@ export function MessageInput({
           onKeyDown={handleKeyDown}
           placeholder="Describe the React component you want to create..."
           disabled={isLoading}
-          className="w-full min-h-[80px] max-h-[200px] pl-4 pr-14 py-3.5 rounded-xl border border-neutral-200 bg-neutral-50/50 text-neutral-900 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500/10 focus:border-blue-500/50 focus:bg-white transition-all placeholder:text-neutral-400 text-[15px] font-normal shadow-sm"
+          className={`w-full min-h-[80px] max-h-[200px] pl-4 pr-14 py-3.5 rounded-xl border bg-neutral-50/50 text-neutral-900 resize-none focus:outline-none focus:ring-2 focus:bg-white transition-all placeholder:text-neutral-400 text-[15px] font-normal shadow-sm ${
+            isOverLimit
+              ? "border-red-400 focus:ring-red-500/10 focus:border-red-500/50"
+              : "border-neutral-200 focus:ring-blue-500/10 focus:border-blue-500/50"
+          }`}
           rows={3}
         />
-        <button 
-          type="submit" 
-          disabled={isLoading || !input.trim()}
+
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim() || isOverLimit}
           className="absolute right-3 bottom-3 p-2.5 rounded-lg transition-all hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent group"
         >
-          <Send className={`h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${isLoading || !input.trim() ? 'text-neutral-300' : 'text-blue-600'}`} />
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 text-blue-600 animate-spin" />
+          ) : (
+            <Send
+              className={`h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${
+                !input.trim() || isOverLimit ? "text-neutral-300" : "text-blue-600"
+              }`}
+            />
+          )}
         </button>
+      </div>
+
+      <div className="flex items-center justify-between max-w-4xl mx-auto mt-2 px-1">
+        <span className="text-xs text-neutral-400">
+          {isLoading ? "Generating response…" : "↵ Enter to send · Shift+Enter for new line"}
+        </span>
+        <span
+          className={`text-xs tabular-nums transition-colors ${
+            isOverLimit
+              ? "text-red-500 font-medium"
+              : isNearLimit
+              ? "text-amber-500"
+              : "text-neutral-400"
+          }`}
+        >
+          {charCount}/{MAX_CHARS}
+        </span>
       </div>
     </form>
   );

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,13 +1,55 @@
 "use client";
 
+import { useState } from "react";
 import { Message } from "ai";
 import { cn } from "@/lib/utils";
-import { User, Bot, Loader2 } from "lucide-react";
+import { User, Bot, Loader2, Copy, Check } from "lucide-react";
 import { MarkdownRenderer } from "./MarkdownRenderer";
 
 interface MessageListProps {
   messages: Message[];
   isLoading?: boolean;
+}
+
+const EXAMPLE_PROMPTS = [
+  "A responsive card component with image, title and action button",
+  "A form with email and password fields and validation",
+  "A navigation bar with logo, links and mobile hamburger menu",
+  "A data table with sortable columns and pagination",
+];
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-md hover:bg-neutral-100 text-neutral-400 hover:text-neutral-600"
+      title="Copy message"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-emerald-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
+
+function extractTextContent(message: Message): string {
+  if (message.parts) {
+    return message.parts
+      .filter((p) => p.type === "text")
+      .map((p) => (p as { type: "text"; text: string }).text)
+      .join("\n");
+  }
+  return message.content ?? "";
 }
 
 export function MessageList({ messages, isLoading }: MessageListProps) {
@@ -17,8 +59,34 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
         <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-blue-50 mb-4 shadow-sm">
           <Bot className="h-7 w-7 text-blue-600" />
         </div>
-        <p className="text-neutral-900 font-semibold text-lg mb-2">Start a conversation to generate React components</p>
-        <p className="text-neutral-500 text-sm max-w-sm">I can help you create buttons, forms, cards, and more</p>
+        <p className="text-neutral-900 font-semibold text-lg mb-2">
+          Start a conversation to generate React components
+        </p>
+        <p className="text-neutral-500 text-sm max-w-sm mb-6">
+          I can help you create buttons, forms, cards, and more
+        </p>
+        <div className="grid grid-cols-1 gap-2 w-full max-w-md">
+          {EXAMPLE_PROMPTS.map((prompt) => (
+            <button
+              key={prompt}
+              className="text-left px-4 py-2.5 rounded-lg border border-neutral-200 bg-white hover:bg-neutral-50 hover:border-blue-300 transition-all text-sm text-neutral-600 shadow-sm"
+              onClick={() => {
+                const textarea = document.querySelector("textarea");
+                if (textarea) {
+                  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+                    window.HTMLTextAreaElement.prototype,
+                    "value"
+                  )?.set;
+                  nativeInputValueSetter?.call(textarea, prompt);
+                  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+                  textarea.focus();
+                }
+              }}
+            >
+              {prompt}
+            </button>
+          ))}
+        </div>
       </div>
     );
   }
@@ -30,7 +98,7 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
           <div
             key={message.id || message.content}
             className={cn(
-              "flex gap-4",
+              "flex gap-4 group",
               message.role === "user" ? "justify-end" : "justify-start"
             )}
           >
@@ -41,17 +109,21 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                 </div>
               </div>
             )}
-            
-            <div className={cn(
-              "flex flex-col gap-2 max-w-[85%]",
-              message.role === "user" ? "items-end" : "items-start"
-            )}>
-              <div className={cn(
-                "rounded-xl px-4 py-3",
-                message.role === "user" 
-                  ? "bg-blue-600 text-white shadow-sm" 
-                  : "bg-white text-neutral-900 border border-neutral-200 shadow-sm"
-              )}>
+
+            <div
+              className={cn(
+                "flex flex-col gap-1 max-w-[85%]",
+                message.role === "user" ? "items-end" : "items-start"
+              )}
+            >
+              <div
+                className={cn(
+                  "rounded-xl px-4 py-3",
+                  message.role === "user"
+                    ? "bg-blue-600 text-white shadow-sm"
+                    : "bg-white text-neutral-900 border border-neutral-200 shadow-sm"
+                )}
+              >
                 <div className="text-sm">
                   {message.parts ? (
                     <>
@@ -59,7 +131,9 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                         switch (part.type) {
                           case "text":
                             return message.role === "user" ? (
-                              <span key={partIndex} className="whitespace-pre-wrap">{part.text}</span>
+                              <span key={partIndex} className="whitespace-pre-wrap">
+                                {part.text}
+                              </span>
                             ) : (
                               <MarkdownRenderer
                                 key={partIndex}
@@ -69,15 +143,23 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                             );
                           case "reasoning":
                             return (
-                              <div key={partIndex} className="mt-3 p-3 bg-white/50 rounded-md border border-neutral-200">
-                                <span className="text-xs font-medium text-neutral-600 block mb-1">Reasoning</span>
+                              <div
+                                key={partIndex}
+                                className="mt-3 p-3 bg-white/50 rounded-md border border-neutral-200"
+                              >
+                                <span className="text-xs font-medium text-neutral-600 block mb-1">
+                                  Reasoning
+                                </span>
                                 <span className="text-sm text-neutral-700">{part.reasoning}</span>
                               </div>
                             );
-                          case "tool-invocation":
+                          case "tool-invocation": {
                             const tool = part.toolInvocation;
                             return (
-                              <div key={partIndex} className="inline-flex items-center gap-2 mt-2 px-3 py-1.5 bg-neutral-50 rounded-lg text-xs font-mono border border-neutral-200">
+                              <div
+                                key={partIndex}
+                                className="inline-flex items-center gap-2 mt-2 px-3 py-1.5 bg-neutral-50 rounded-lg text-xs font-mono border border-neutral-200"
+                              >
                                 {tool.state === "result" && tool.result ? (
                                   <>
                                     <div className="w-2 h-2 rounded-full bg-emerald-500"></div>
@@ -91,6 +173,7 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                                 )}
                               </div>
                             );
+                          }
                           case "source":
                             return (
                               <div key={partIndex} className="mt-2 text-xs text-neutral-500">
@@ -98,7 +181,9 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                               </div>
                             );
                           case "step-start":
-                            return partIndex > 0 ? <hr key={partIndex} className="my-3 border-neutral-200" /> : null;
+                            return partIndex > 0 ? (
+                              <hr key={partIndex} className="my-3 border-neutral-200" />
+                            ) : null;
                           default:
                             return null;
                         }
@@ -128,8 +213,14 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                   ) : null}
                 </div>
               </div>
+
+              {message.role === "assistant" && (
+                <div className="flex items-center px-1">
+                  <CopyButton text={extractTextContent(message)} />
+                </div>
+              )}
             </div>
-            
+
             {message.role === "user" && (
               <div className="flex-shrink-0">
                 <div className="w-9 h-9 rounded-lg bg-blue-600 shadow-sm flex items-center justify-center">

--- a/src/components/chat/__tests__/MessageInput.test.tsx
+++ b/src/components/chat/__tests__/MessageInput.test.tsx
@@ -16,7 +16,7 @@ test("renders with placeholder text", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByPlaceholderText("Describe the React component you want to create...");
   expect(textarea).toBeDefined();
 });
@@ -30,7 +30,7 @@ test("displays the input value", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByDisplayValue("Test input value");
   expect(textarea).toBeDefined();
 });
@@ -45,10 +45,10 @@ test("calls handleInputChange when typing", async () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByPlaceholderText("Describe the React component you want to create...");
   await userEvent.type(textarea, "Hello");
-  
+
   expect(handleInputChange).toHaveBeenCalled();
 });
 
@@ -62,10 +62,10 @@ test("calls handleSubmit when form is submitted", async () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const form = screen.getByRole("textbox").closest("form")!;
   fireEvent.submit(form);
-  
+
   expect(handleSubmit).toHaveBeenCalledOnce();
 });
 
@@ -79,10 +79,10 @@ test("submits form when Enter is pressed without shift", async () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByRole("textbox");
   fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
-  
+
   expect(handleSubmit).toHaveBeenCalledOnce();
 });
 
@@ -96,10 +96,10 @@ test("does not submit form when Enter is pressed with shift", async () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByRole("textbox");
   fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
-  
+
   expect(handleSubmit).not.toHaveBeenCalled();
 });
 
@@ -112,7 +112,7 @@ test("disables textarea when isLoading is true", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByRole("textbox");
   expect(textarea).toHaveProperty("disabled", true);
 });
@@ -126,7 +126,7 @@ test("disables submit button when isLoading is true", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const submitButton = screen.getByRole("button");
   expect(submitButton).toHaveProperty("disabled", true);
 });
@@ -140,7 +140,7 @@ test("disables submit button when input is empty", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const submitButton = screen.getByRole("button");
   expect(submitButton).toHaveProperty("disabled", true);
 });
@@ -154,7 +154,7 @@ test("disables submit button when input contains only whitespace", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const submitButton = screen.getByRole("button");
   expect(submitButton).toHaveProperty("disabled", true);
 });
@@ -168,13 +168,13 @@ test("enables submit button when input has content and not loading", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const submitButton = screen.getByRole("button");
   expect(submitButton).toHaveProperty("disabled", false);
 });
 
-test("applies correct CSS classes based on loading state", () => {
-  const { rerender } = render(
+test("applies correct CSS classes to submit button", () => {
+  render(
     <MessageInput
       input="Test"
       handleInputChange={vi.fn()}
@@ -183,11 +183,14 @@ test("applies correct CSS classes based on loading state", () => {
     />
   );
 
-  let submitButton = screen.getByRole("button");
+  const submitButton = screen.getByRole("button");
   expect(submitButton.className).toContain("disabled:opacity-40");
   expect(submitButton.className).toContain("hover:bg-blue-50");
+  expect(submitButton.className).toContain("disabled:cursor-not-allowed");
+});
 
-  rerender(
+test("shows Loader2 spinner icon when isLoading is true", () => {
+  render(
     <MessageInput
       input="Test"
       handleInputChange={vi.fn()}
@@ -196,13 +199,14 @@ test("applies correct CSS classes based on loading state", () => {
     />
   );
 
-  submitButton = screen.getByRole("button");
-  expect(submitButton.className).toContain("disabled:cursor-not-allowed");
-  expect(submitButton.className).toContain("disabled:opacity-40");
+  const submitButton = screen.getByRole("button");
+  const svg = submitButton.querySelector("svg");
+  // Loader2 spinner has animate-spin class
+  expect(svg?.getAttribute("class")).toContain("animate-spin");
 });
 
-test("applies pulse animation to send icon when loading", () => {
-  const { rerender } = render(
+test("shows Send icon when not loading", () => {
+  render(
     <MessageInput
       input="Test"
       handleInputChange={vi.fn()}
@@ -211,20 +215,10 @@ test("applies pulse animation to send icon when loading", () => {
     />
   );
 
-  let sendIcon = screen.getByRole("button").querySelector("svg");
-  expect(sendIcon?.getAttribute("class")).not.toContain("animate-pulse");
-
-  rerender(
-    <MessageInput
-      input="Test"
-      handleInputChange={vi.fn()}
-      handleSubmit={vi.fn()}
-      isLoading={true}
-    />
-  );
-
-  sendIcon = screen.getByRole("button").querySelector("svg");
-  expect(sendIcon?.getAttribute("class")).toContain("text-neutral-300");
+  const submitButton = screen.getByRole("button");
+  const svg = submitButton.querySelector("svg");
+  // Send icon does not have animate-spin
+  expect(svg?.getAttribute("class")).not.toContain("animate-spin");
 });
 
 test("textarea has correct styling classes", () => {
@@ -236,13 +230,53 @@ test("textarea has correct styling classes", () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const textarea = screen.getByRole("textbox");
   expect(textarea.className).toContain("min-h-[80px]");
   expect(textarea.className).toContain("max-h-[200px]");
   expect(textarea.className).toContain("resize-none");
   expect(textarea.className).toContain("focus:ring-2");
-  expect(textarea.className).toContain("focus:ring-blue-500/10");
+});
+
+test("disables submit button when input exceeds 2000 characters", () => {
+  const longInput = "a".repeat(2001);
+  const mockProps = {
+    input: longInput,
+    handleInputChange: vi.fn(),
+    handleSubmit: vi.fn(),
+    isLoading: false,
+  };
+
+  render(<MessageInput {...mockProps} />);
+
+  const submitButton = screen.getByRole("button");
+  expect(submitButton).toHaveProperty("disabled", true);
+});
+
+test("shows character count in footer", () => {
+  const mockProps = {
+    input: "hello",
+    handleInputChange: vi.fn(),
+    handleSubmit: vi.fn(),
+    isLoading: false,
+  };
+
+  render(<MessageInput {...mockProps} />);
+
+  expect(screen.getByText("5/2000")).toBeDefined();
+});
+
+test("shows loading hint text when isLoading is true", () => {
+  render(
+    <MessageInput
+      input=""
+      handleInputChange={vi.fn()}
+      handleSubmit={vi.fn()}
+      isLoading={true}
+    />
+  );
+
+  expect(screen.getByText("Generating response…")).toBeDefined();
 });
 
 test("submit button click triggers form submission", async () => {
@@ -255,9 +289,9 @@ test("submit button click triggers form submission", async () => {
   };
 
   render(<MessageInput {...mockProps} />);
-  
+
   const submitButton = screen.getByRole("button");
   await userEvent.click(submitButton);
-  
+
   expect(handleSubmit).toHaveBeenCalledOnce();
 });


### PR DESCRIPTION
## Summary

- **MessageInput**: add character counter (limit 2000), animated loading spinner on send button, keyboard shortcut hint (↵ Enter / Shift+Enter), red border when over limit
- **MessageList**: add copy-to-clipboard button on assistant messages (visible on hover), replace generic empty state with 4 clickable example prompts that populate the textarea

## Changes

| File | Change |
|---|---|
| `src/components/chat/MessageInput.tsx` | Char counter, Loader2 spinner, keyboard hint footer, over-limit guard |
| `src/components/chat/MessageList.tsx` | `CopyButton` component, `EXAMPLE_PROMPTS` clickable chips, `extractTextContent` helper |

## Test plan
- [ ] Type >1700 chars → counter turns amber, >2000 → red border + send disabled
- [ ] Click example prompt chip → textarea fills with text and gains focus
- [ ] Hover over assistant message → copy icon appears, click copies text
- [ ] Send message → spinner shows in send button while loading

🤖 Generated with [Claude Code](https://claude.ai/claude-code)